### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,4 @@ jobs:
       extension-name: CouchbaseExplorer
       display-name: 'Couchbase Explorer'
       marketplace-id: CodingWithCalvin.VS-CouchbaseExplorer
-      description: 'Browse and manage your Couchbase Server data directly from Visual Studio'
-      hashtags: '#couchbase #nosql'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly