### PR TITLE
ci(build): skip build on readme-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,16 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     paths:
       - 'src/**'
-      - '*.slnx'
       - '.github/workflows/build.yml'
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `paths` filter to `push` trigger so README-only commits (from the scheduled contributors workflow) no longer fire a build on main
- Add `synchronize` to PR trigger types so PR updates are actually rebuilt
- Drop dead `'*.slnx'` path glob — the solution file lives under `src/` so `src/**` already covers it

## Test plan
- [ ] Confirm next scheduled contributors run does not trigger Build
- [ ] Confirm a `src/**` push still triggers Build
- [ ] Confirm PR sync still triggers Build